### PR TITLE
fix: incorrect font used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-pane",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/style.scss
+++ b/src/style.scss
@@ -44,6 +44,8 @@
   padding-top: 1.375rem;
   height: 5.625rem;
   min-width: 4.25rem;
+  font-family: var(--auro-font-family-default);
+  font-weight: var(--auro-text-body-default-weight);
 
   background: var(--auro-color-base-gray-100);
   border: 2px solid;


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:

This PR sets font-family and font-weight on the button. It was falling back to Tahoma because buttons don't inherit font settings.

Before:
![before](https://user-images.githubusercontent.com/4992896/94836009-4e2ed780-03c7-11eb-9896-34e76d3da755.png)

After:
![after](https://user-images.githubusercontent.com/4992896/94836024-52f38b80-03c7-11eb-99c5-5592d5f1c685.png)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
