### PR TITLE
fix: ndash for non-unicode support

### DIFF
--- a/src/auro-pane.js
+++ b/src/auro-pane.js
@@ -6,6 +6,7 @@
 import { LitElement, html, css } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
+import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
 
 // Import touch detection lib
 import 'focus-visible/dist/focus-visible.min.js';

--- a/src/auro-pane.js
+++ b/src/auro-pane.js
@@ -121,7 +121,7 @@ class AuroPane extends LitElement {
         'child': true
       };
 
-      return html`<span class="${classMap(priceClasses)}">${this.disabled ? "––" : this.price}</span>`
+      return html`<span class="${classMap(priceClasses)}">${this.disabled ? unsafeHTML('&ndash;&ndash;') : this.price}</span>`
     }
 
     return html``;


### PR DESCRIPTION
# Alaska Airlines Pull Request

On AScom, the unicode ndashes baked into the component were appearing like so:
![image](https://user-images.githubusercontent.com/7005799/96295150-4879ea00-0fa2-11eb-85a0-e66578d63591.png)

This uses the &ndash; escaped equivalent, which does work.

**Fixes:** # (issue, if applicable)

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
