### PR TITLE
fix: default boolean props to false

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,17 +2,22 @@
 
 auro-pane displays shoulder date information
 
+## Attributes
+
+| Attribute | Type      | Description                              |
+|-----------|-----------|------------------------------------------|
+| `fixed`   | `Boolean` | uses px values instead of rem for fonts. |
+
 ## Properties
 
-| Property     | Attribute     | Type      | Description                                      |
-|--------------|---------------|-----------|--------------------------------------------------|
-| `ariaHidden` | `aria-hidden` | `String`  | Sets aria-hidden on the inner button.            |
-| `date`       | `date`        | `String`  | Sets date for parsing and display. Format should be yyyy-mm-dd. |
-| `disabled`   | `disabled`    | `Boolean` | Disables the pane and overrides price to be --.  |
-| `fixed`      | `fixed`       | `Boolean` | uses px values instead of rem for fonts.         |
-| `price`      | `price`       | `String`  | Sets price for display. Displayed as is.         |
-| `selected`   | `selected`    | `Boolean` | Sets pane state to selected.                     |
-| `tabIndex`   | `tabIndex`    | `Number`  | Sets tabindex on the inner button.               |
+| Property     | Attribute     | Type      | Default | Description                                      |
+|--------------|---------------|-----------|---------|--------------------------------------------------|
+| `ariaHidden` | `aria-hidden` | `String`  |         | Sets aria-hidden on the inner button.            |
+| `date`       | `date`        | `String`  |         | Sets date for parsing and display. Format should be yyyy-mm-dd. |
+| `disabled`   | `disabled`    | `Boolean` | false   | Disables the pane and overrides price to be --.  |
+| `price`      | `price`       | `String`  |         | Sets price for display. Displayed as is.         |
+| `selected`   | `selected`    | `Boolean` | false   | Sets pane state to selected.                     |
+| `tabIndex`   | `tabIndex`    | `Number`  |         | Sets tabindex on the inner button.               |
 
 ## Methods
 

--- a/src/auro-pane.js
+++ b/src/auro-pane.js
@@ -60,6 +60,9 @@ class AuroPane extends LitElement {
       'Nov',
       'Dec'
     ];
+
+    this.disabled = false;
+    this.selected = false;
   }
 
   static get properties() {
@@ -70,7 +73,6 @@ class AuroPane extends LitElement {
       },
       date: { type: String },
       disabled: { type: Boolean },
-      fixed: { type: Boolean },
       price: { type: String },
       selected: { type: Boolean },
       tabIndex: { type: Number },


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #11

## Summary:

- Default boolean props to false
- Remove `fixed` property since it wasn't being used as a property. It was only being used as an attribute as a styling hook (e.g. `:host([fixed])`). This should have no effect on the consumer -- if people were setting the property, it wasn't working since it wasn't being reflected.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
