### PR TITLE
fix: correct date formatting in UTC+ timezones #14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-pane",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5123,6 +5123,11 @@
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
+    },
+    "dayjs": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "debounce": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "lit-element": "^2.4.0",
-    "chalk": "^4.1.0"
+    "chalk": "^4.1.0",
+    "dayjs": "^1.10.6",
+    "lit-element": "^2.4.0"
   },
   "peerDependencies": {
     "@alaskaairux/orion-design-tokens": "^2.12.1",

--- a/src/auro-pane.js
+++ b/src/auro-pane.js
@@ -6,7 +6,8 @@
 import { LitElement, html, css } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
 import { ifDefined } from 'lit-html/directives/if-defined';
-import {unsafeHTML} from 'lit-html/directives/unsafe-html.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
+import dayjs from 'dayjs/esm';
 
 // Import touch detection lib
 import 'focus-visible/dist/focus-visible.min.js';
@@ -29,37 +30,6 @@ import styleCssFixed from './style-fixed-css.js';
 class AuroPane extends LitElement {
   constructor() {
     super();
-
-    /**
-     * @private
-     */
-    this.weekdays = [
-      'Sun',
-      'Mon',
-      'Tue',
-      'Wed',
-      'Thu',
-      'Fri',
-      'Sat'
-    ];
-
-    /**
-     * @private
-     */
-    this.months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec'
-    ];
 
     this.disabled = false;
     this.selected = false;
@@ -92,19 +62,13 @@ class AuroPane extends LitElement {
    * @returns {Object} object containing day, date, and month
    */
   parseDateString() {
-    const dateFormatLength = 10;
+    const parsedDate = dayjs(this.date);
 
-    if (this.date && this.date.length === dateFormatLength) {
-      // Using substring instead of date parsing due to browser inconsistencies
-      const year = this.date.substring(0, 4),
-        month = this.date.substring(5, 7),
-        date = this.date.substring(8),
-        parsedDate = new Date(year, month - 1, date);
-
+    if (parsedDate.isValid()) {
       return {
-        day: this.weekdays[parsedDate.getUTCDay()],
-        date: parsedDate.getUTCDate(),
-        month: this.months[parsedDate.getUTCMonth()]
+        day: parsedDate.format('ddd'),
+        date: parsedDate.format('D'),
+        month: parsedDate.format('MMM')
       };
     }
 

--- a/test/auro-pane.test.js
+++ b/test/auro-pane.test.js
@@ -21,6 +21,7 @@ describe('auro-pane', () => {
     ["2020-09-09", "Wed Sep 9"],
     ["2020-01-11", "Sat Jan 11"],
     ["invalid date", ""],
+    [null, ""],
   ]
 
   dateTestCases.forEach(async function ([date, expected]) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #14

## Summary:

Use [dayjs](https://day.js.org/en/) for date formatting to fix bug with UTC+ timezones.

Validated on the local demo page by setting my timezone to Amsterdam (UTC +1) and restarting the browser. With those settings, date is [incorrect](https://auro.alaskaair.com/components/auro/pane/) on the doc site but correct on the local demo.

Not sure how to unit test this, but existing tests pass.

Demo screenshot:
![image](https://user-images.githubusercontent.com/4992896/130133005-ebbeda47-a50f-45fb-9a2f-e414f96d066f.png)


## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
