### PR TITLE
fix(price): update the getPrice function to require 8 char to add price--long class vs 6 char #38

### DIFF
--- a/src/auro-pane.js
+++ b/src/auro-pane.js
@@ -84,7 +84,7 @@ class AuroPane extends LitElement {
     if (this.price !== undefined) {
       const priceClasses = {
         'price': true,
-        'price--long': this.price.length > 6,
+        'price--long': this.price.length > 8,
         'child': true,
         'price--empty': this.price === ''
       };

--- a/test/auro-pane.test.js
+++ b/test/auro-pane.test.js
@@ -52,6 +52,14 @@ describe('auro-pane', () => {
     expect(isPanePricedClassPresent(el)).to.be.true;
   })
 
+  it('does not not display the smaller text for less than 8 characters in the price', async () => {
+    const el = await fixture(html`
+      <auro-pane date="2020-09-09" price="12.5k +" disabled></auro-pane>
+    `);
+    expect(getButtonText(el)).to.equal("Wed Sep 9 12.5k +");
+    expect(isPriceLongClassPresent(el)).to.not.be.true;
+  })
+
   it('displays two dashes when price attribute is empty', async () => {
     const el = await fixture(html`
       <auro-pane date="2020-09-09" price=""></auro-pane>
@@ -96,4 +104,9 @@ function getButtonText(el) {
 function isPanePricedClassPresent(el) {
   const button = el.shadowRoot.querySelector('button');
   return button.classList.contains('pane-priced');
+}
+
+function isPriceLongClassPresent(el) {
+  const button = el.shadowRoot.querySelector('button');
+  return button.classList.contains('price--long');
 }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #38 

## Summary:
I have made updates to the getPrice function so that the text that shows the prices in the panes are consistent up to 8 characters long instead of 6 characters long. 

![Screen Shot 2023-06-09 at 1 41 08 PM](https://github.com/AlaskaAirlines/auro-pane/assets/107429014/a954be99-4ed3-444a-ad45-59920c88131b)

![Screen Shot 2023-06-09 at 1 41 01 PM](https://github.com/AlaskaAirlines/auro-pane/assets/107429014/219b4a5b-e711-4519-bc2e-06dcb6837508)

## Type of change:

Please delete options that are not relevant.

- [X] Revision of an existing capability

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
